### PR TITLE
Perbaiki error get_diff signature di CLI runtime

### DIFF
--- a/openhands/runtime/impl/cli/cli_runtime.py
+++ b/openhands/runtime/impl/cli/cli_runtime.py
@@ -44,13 +44,13 @@ except ImportError:
             self.old_content = old_content
             self.new_content = new_content
     
-    def get_diff(old_content: str, new_content: str) -> str:
+    def get_diff(old_contents: str, new_contents: str, filepath: str = 'file') -> str:
         """Fallback diff implementation."""
         diff = list(difflib.unified_diff(
-            old_content.splitlines(keepends=True),
-            new_content.splitlines(keepends=True),
-            fromfile='old',
-            tofile='new'
+            old_contents.splitlines(keepends=True),
+            new_contents.splitlines(keepends=True),
+            fromfile=f'{filepath} (old)',
+            tofile=f'{filepath} (new)'
         ))
         return ''.join(diff)
     


### PR DESCRIPTION
## Masalah

Setelah perbaikan sebelumnya untuk error `'OHEditor' object is not callable`, muncul error baru:

```
TypeError: get_diff() got an unexpected keyword argument 'old_contents'
```

## Akar Masalah

Implementasi fallback `get_diff()` di `cli_runtime.py` memiliki signature yang tidak cocok dengan fungsi asli dari `openhands_aci`:

- **Fungsi asli**: `get_diff(old_contents: str, new_contents: str, filepath: str = 'file')`
- **Fallback**: `get_diff(old_content: str, new_content: str)` ❌

Kode di `action_execution_server.py` memanggil `get_diff()` dengan parameter `old_contents` dan `new_contents`, tetapi implementasi fallback menggunakan `old_content` dan `new_content`.

## Solusi

### 1. Perbaiki Signature Fungsi
```python
# Sebelum (salah):
def get_diff(old_content: str, new_content: str) -> str:

# Sesudah (benar):  
def get_diff(old_contents: str, new_contents: str, filepath: str = 'file') -> str:
```

### 2. Tambahkan Parameter `filepath`
- Menambahkan parameter `filepath` dengan default value `'file'`
- Menggunakan `filepath` untuk output diff yang lebih informatif

### 3. Perbaiki Output Diff
```python
# Sebelum:
fromfile='old', tofile='new'

# Sesudah:
fromfile=f'{filepath} (old)', tofile=f'{filepath} (new)'
```

## Testing

- ✅ `get_diff()` bekerja dengan parameter `old_contents`, `new_contents`, `filepath`
- ✅ `get_diff()` bekerja dengan parameter default (tanpa `filepath`)
- ✅ Output diff lebih informatif dengan nama file
- ✅ Kompatibel dengan interface asli dari `openhands_aci`
- ✅ Tidak ada syntax error atau import error

## Status Perbaikan

Kedua error utama di CLI runtime sekarang sudah teratasi:

1. ✅ **TypeError: 'OHEditor' object is not callable** (diperbaiki di PR sebelumnya)
2. ✅ **TypeError: get_diff() got an unexpected keyword argument 'old_contents'** (diperbaiki di PR ini)

## Files Changed

- `openhands/runtime/impl/cli/cli_runtime.py`: Memperbaiki signature fungsi `get_diff()` untuk mencocokkan interface asli

## Impact

Perbaikan ini melengkapi solusi untuk error CLI runtime dan memastikan agent tidak lagi transition ke ERROR state karena masalah signature fungsi yang tidak cocok.

@Kugylove can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6321cb1aaa514cedb3d15a35dd29432f)